### PR TITLE
Added the ability to highlight multiple stores and remove said stores.

### DIFF
--- a/fass-react/src/components/MapComponent.js
+++ b/fass-react/src/components/MapComponent.js
@@ -78,7 +78,6 @@ export function initializeMap(mapId, households, stores) {
         red_house: getMapIcon('house-red.svg', 'shadow.svg')
     };
 
-    //
     // rendering functions
     //
 
@@ -199,8 +198,79 @@ export function initializeMap(mapId, households, stores) {
 
         // add marker to layer
         //
-        L.marker(position, {icon: icon}).addTo(layer).bindPopup(getStorePopup(store));
+        const marker = L.marker(position, {icon: icon}).addTo(layer).bindPopup(getStorePopup(store));
+        // Keep trach of each store's highlight state and ID for future reference
+        marker.isHighlighted = false;
+        marker.storeId = store.store_id;
+
+        // When clicked, toggle highlight state and update marker highlighting on map
+        marker.on('click', () => {
+            marker.isHighlighted = !marker.isHighlighted;
+            if(marker.getElement()) {
+                marker.getElement().style.filter = marker.isHighlighted ? 'drop-shadow(0 0 0px red) drop-shadow(0 0 0px red) drop-shadow(0 0 0px red)' : '';
+            }
+        });
+
+        // Store the markers in window
+        window.storeMarkers = window.storeMarkers || [];
+        window.storeMarkers.push(marker);
     }
+
+    function deleteHighlightedStores() {
+        // Get only the highlighted store markers
+        const highlightedStores = storeMarkers.filter(marker => marker.isHighlighted);
+
+        // Run backend delete for each highlighted store
+        highlightedStores.forEach(marker => {
+            const storeID = marker.storeId;
+            client.delete('/stores', {
+                params: {
+                    store_id: storeID,
+                    simulation_instance_id: getSimulationInstanceId(),
+                    simulation_step: getSimulationStep(),
+                }
+            })
+            .then(response => {
+                console.log('Stores removed:', highlightedStores.length);
+                
+                // Remove the marker from the map
+                map.removeLayer(marker);
+
+                // Remove marker from storeMarkers array
+                const index = storeMarkers.indexOf(marker);
+                if (index > -1) storeMarkers.splice(index, 1);
+
+                // Update frontend store list
+                window.stores = response.data.store_json;
+
+                // update map
+                rerender();
+            })
+            .catch(error => {
+                console.error('Error removing store:', error);
+            });
+        });
+    }
+
+    function handleRemoveStores() {
+    if (!window.storeMarkers) {
+        console.warn('No store markers found.');
+        return false;
+    }
+
+    const highlighted = window.storeMarkers.filter(m => m.isHighlighted);
+    if (highlighted.length === 0) return false;
+
+    const confirmed = window.confirm(`Would you like to delete these ${highlighted.length} store(s)?`);
+    if (!confirmed) return false;
+
+    // Call the existing delete logic
+    deleteHighlightedStores();
+    return true;
+    }
+
+    // Alloe React to call this function in the RemoveStoreButton component
+    window.handleRemoveStores = handleRemoveStores;
 
     function renderStores(stores, layer, households, limit=0) {
         stores.forEach((store, index) => {

--- a/fass-react/src/components/RemoveStoreButton.jsx
+++ b/fass-react/src/components/RemoveStoreButton.jsx
@@ -5,11 +5,20 @@ import RemoveStoreModal from './RemoveStoreModal';
 const RemoveStoreButton = () => {
     const [showModal, setShowModal] = useState(false);
     const handleClose = () => setShowModal(false);
-    const handleShow = () => setShowModal(true);
+    //const handleShow = () => setShowModal(true);
+
+    const handleClick = () => {
+      // Remove highlighted stores directly
+      const handled = window.handleRemoveStores?.();
+      if (!handled) {
+        // If no highlighted stores, show modal for manual selection
+        setShowModal(true);
+      }
+    };
 
     return (
       <>
-       <Button variant="primary" onClick={handleShow}>
+       <Button variant="primary" onClick={handleClick}>
         Remove Store
         </Button>
         <RemoveStoreModal show={showModal} handleClose={handleClose} />


### PR DESCRIPTION
Stores can now be highlighted (in red) when pressed. The selection operates like an on and off switch so that you can highlight and unhighlight stores. When the Remove Store button is pressed on the sidebar, a dialogue confirmation appears asking the user if they want to remove the highlighted stores. If there are no highlighted stores, the original form pop-up appears instead. If the user presses "OK" on the dialogue confirmation, all highlighted stores are removed. If the user presses "Cancel" on the dialogue confirmation, the original form pop-up appears.