### PR TITLE
Changed Help button functionality; Help button now opens FEAST website.

### DIFF
--- a/fass-react/src/components/TopBar.jsx
+++ b/fass-react/src/components/TopBar.jsx
@@ -13,7 +13,7 @@ const TopBar = () => {
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav">
       </Navbar.Collapse>
-      <Button onClick={handleShow}>Help</Button>
+      <Button onClick={() => window.open('https://foodaccesssimulator.org', '_blank')}>Help</Button>
       <HelpModal show={showModal} handleClose={handleClose} />
     </Navbar>
   );


### PR DESCRIPTION
When the Help button is clicked, the user is redirected to the FEAST website (https://foodaccesssimulator.org) in a new tab.