### PR TITLE
Revert "Added the ability to highlight multiple stores and remove said stores. (Redoing the PR after revert)"

### DIFF
--- a/fass-react/src/components/MapComponent.js
+++ b/fass-react/src/components/MapComponent.js
@@ -78,6 +78,7 @@ export function initializeMap(mapId, households, stores) {
         red_house: getMapIcon('house-red.svg', 'shadow.svg')
     };
 
+    //
     // rendering functions
     //
 
@@ -172,24 +173,10 @@ export function initializeMap(mapId, households, stores) {
                 .then(response => {
                     console.log('Store removed:', store.name);
 
-                    // Make sure to untrack the store removed via popup (don't include as a highlighted marker)
-                    const highlightedStores = window.storeMarkers.filter(marker => marker.isHighlighted);
-                    highlightedStores.forEach(marker => {
-                        const storeID = marker.storeId;
-                        if(storeID === store.store_id) {
-                            // Remove the marker from the map
-                            map.removeLayer(marker);
-
-                            // Remove marker from storeMarkers array
-                            const index = window.storeMarkers.indexOf(marker);
-                            if (index > -1) window.storeMarkers.splice(index, 1);
-                       }
-                    });
-
                     // update map
                     //
                     window.stores = response.data.store_json;
-                    //rerender();
+                    rerender();
                 })
             } 
             catch(error) {
@@ -203,7 +190,7 @@ export function initializeMap(mapId, households, stores) {
         table.appendChild(tbody);
         return table;
     }
-    
+
     function renderStore(store, layer) {
         const array = parsePolygon(store.geometry);
         const point = array[0];
@@ -212,81 +199,8 @@ export function initializeMap(mapId, households, stores) {
 
         // add marker to layer
         //
-        const marker = L.marker(position, {icon: icon}).addTo(layer).bindPopup(getStorePopup(store));
-        // Keep trach of each store's highlight state and ID for future reference
-        marker.isHighlighted = false;
-        marker.storeId = store.store_id;
-
-        // When clicked, toggle highlight state and update marker highlighting on map
-        marker.on('click', () => {
-            marker.isHighlighted = !marker.isHighlighted;
-            if(marker.getElement()) {
-                marker.getElement().style.filter = marker.isHighlighted ? 'drop-shadow(0 0 0px red) drop-shadow(0 0 0px red) drop-shadow(0 0 0px red)' : '';
-            }
-        });
-
-        // Store the markers in window
-        window.storeMarkers = window.storeMarkers || [];
-        window.storeMarkers.push(marker);
+        L.marker(position, {icon: icon}).addTo(layer).bindPopup(getStorePopup(store));
     }
-
-    function deleteHighlightedStores() {
-        // Get only the highlighted store markers
-        const highlightedStores = window.storeMarkers.filter(marker => marker.isHighlighted);
-
-        // Run backend delete for each highlighted store
-        highlightedStores.forEach(marker => {
-            const storeID = marker.storeId;
-            client.delete('/stores', {
-                params: {
-                    store_id: storeID,
-                    simulation_instance_id: getSimulationInstanceId(),
-                    simulation_step: getSimulationStep(),
-                }
-            })
-            .then(response => {
-                console.log('Stores removed:', highlightedStores.length);
-                
-                // Remove the marker from the map
-                map.removeLayer(marker);
-
-                // Remove marker from storeMarkers array
-                const index = window.storeMarkers.indexOf(marker);
-                if (index > -1) window.storeMarkers.splice(index, 1);
-
-                // Update frontend store list
-                window.stores = response.data.store_json;
-
-                // update map
-                rerender();
-            })
-            .catch(error => {
-                console.error('Error removing store:', error);
-            });
-        });
-    }
-
-    function handleRemoveStores() {
-        if (!window.storeMarkers) {
-            console.warn('No store markers found.');
-            return false;
-        }
-
-        // Get only the highlighted store markers
-        const highlighted = window.storeMarkers.filter(m => m.isHighlighted);
-        if (highlighted.length === 0) return false;
-
-        // Confirmation popup
-        const confirmed = window.confirm(`Would you like to delete these ${highlighted.length} store(s)?`);
-        if (!confirmed) return false;
-
-        // Call the existing delete logic
-        deleteHighlightedStores();
-        return true;
-    }
-
-    // Allow React to call this function in the RemoveStoreButton component
-    window.handleRemoveStores = handleRemoveStores;
 
     function renderStores(stores, layer, households, limit=0) {
         stores.forEach((store, index) => {

--- a/fass-react/src/components/RemoveStoreButton.jsx
+++ b/fass-react/src/components/RemoveStoreButton.jsx
@@ -1,29 +1,20 @@
 import React, { useState } from 'react';
-import { Button } from 'react-bootstrap';
+import { Modal, Button, Form } from 'react-bootstrap';
 import RemoveStoreModal from './RemoveStoreModal';
 
 const RemoveStoreButton = () => {
     const [showModal, setShowModal] = useState(false);
     const handleClose = () => setShowModal(false);
-
-    const handleClick = () => {
-      // Try to remove highlighted stores directly
-      const handled = window.handleRemoveStores?.();
-      if (!handled) {
-        // No highlighted stores, show modal for manual selection
-        setShowModal(true);
-      }
-    };
+    const handleShow = () => setShowModal(true);
 
     return (
       <>
-       <Button variant="primary" onClick={handleClick}>
+       <Button variant="primary" onClick={handleShow}>
         Remove Store
-       </Button>
-       <RemoveStoreModal show={showModal} handleClose={handleClose} />
+        </Button>
+        <RemoveStoreModal show={showModal} handleClose={handleClose} />
       </>
     );
-};
-
-export default RemoveStoreButton;
+  };
   
+  export default RemoveStoreButton;


### PR DESCRIPTION
There are a few remaining issues:

1. The new store types are unselectable.

2. The popups still display the "Remove Store" button so when a store is selected, there are two remove store buttons that do the same thing (on the sidebar and on the popup).  Since we have the sidebar button, we don't need the popup button.

3. After clicking cancel on the confirm dialog, the previous select by list dialog is displayed.  This is undesirable since the user has just cancelled and there's not a reason why they would want to add a store using the selection list.

4. The confirm dialog that comes up is a browser alert dialog rather than an application dialog, which works but is not ideal.   It's inconsistent with the aesthetics of the other dialogs.

5. Stores don't deselect when clicking on the map.   The individual toggling of store icons works to deselect each store one by one, but most users will expect the stores to all be deselected when clicking on the map.   The usual / standard selection behavior is as follows:

    a) when a new item is selected, any previously selected items are deselected.  
    b) to select multiple items, usually a shift or control key is held down while clicking to select.
    c) when the background element is selected, all currently selected items are deselected.

6. The color red is usually used as a warning / error color.  We might try another color (yellow, blue etc.) as a selection color.   Possibly use the signature / brand color, which is used for the buttons etc.  Another option is to display a square outline around the marker to make it easier to see (using the css "outline" property).