### PR TITLE
Fixed Remaining Issues For Multi-Select Store Removal Functionality

### DIFF
--- a/fass-react/src/components/MapComponent.js
+++ b/fass-react/src/components/MapComponent.js
@@ -1,62 +1,3 @@
-
-    function deleteHighlightedStores() {
-        // Get only the highlighted store markers
-        const highlightedStores = window.storeMarkers.filter(marker => marker.isHighlighted);
-
-        // Run backend delete for each highlighted store
-        highlightedStores.forEach(marker => {
-            const storeID = marker.storeId;
-            client.delete('/stores', {
-                params: {
-                    store_id: storeID,
-                    simulation_instance_id: getSimulationInstanceId(),
-                    simulation_step: getSimulationStep(),
-                }
-            })
-            .then(response => {
-                console.log('Stores removed:', highlightedStores.length);
-                
-                // Remove the marker from the map
-                map.removeLayer(marker);
-
-                // Remove marker from storeMarkers array
-                const index = window.storeMarkers.indexOf(marker);
-                if (index > -1) window.storeMarkers.splice(index, 1);
-
-                // Update frontend store list
-                window.stores = response.data.store_json;
-
-                // update map
-                rerender();
-            })
-            .catch(error => {
-                console.error('Error removing store:', error);
-            });
-        });
-    }
-
-    function handleRemoveStores() {
-        if (!window.storeMarkers) {
-            console.warn('No store markers found.');
-            return false;
-        }
-
-        // Get only the highlighted store markers
-        const highlighted = window.storeMarkers.filter(m => m.isHighlighted);
-        if (highlighted.length === 0) return false;
-
-        // Confirmation popup
-        const confirmed = window.confirm(`Would you like to delete these ${highlighted.length} store(s)?`);
-        if (!confirmed) return false;
-
-        // Call the existing delete logic
-        deleteHighlightedStores();
-        return true;
-    }
-
-    // Allow React to call this function in the RemoveStoreButton component
-    window.handleRemoveStores = handleRemoveStores;
-
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import proj4 from 'proj4';
@@ -209,53 +150,53 @@ export function initializeMap(mapId, households, stores) {
         //
         const tr3 = document.createElement("tr");
         const td3 = document.createElement("td");
-        const button = document.createElement("button");
-        button.textContent = "Remove Store";
-        button.style.padding = "8px 8px";
-        button.style.color = "white";
-        button.style.cursor = "pointer";
-        button.style.backgroundColor = "#0d6efd";
-        button.style.marginTop = "10px";
-        button.style.marginBottom = "10px";
-        button.style.borderRadius = "6px";
+        // const button = document.createElement("button");
+        // button.textContent = "Remove Store";
+        // button.style.padding = "8px 8px";
+        // button.style.color = "white";
+        // button.style.cursor = "pointer";
+        // button.style.backgroundColor = "#0d6efd";
+        // button.style.marginTop = "10px";
+        // button.style.marginBottom = "10px";
+        // button.style.borderRadius = "6px";
 
-        button.addEventListener("click", () => {
-            try {
-                client.delete('/stores', {
-                    params: {
-                    store_id: store.store_id, 
-                    simulation_instance_id: getSimulationInstanceId(),
-                    simulation_step: getSimulationStep(),
-                    }
-                })
-                .then(response => {
-                    console.log('Store removed:', store.name);
+        // button.addEventListener("click", () => {
+        //     try {
+        //         client.delete('/stores', {
+        //             params: {
+        //             store_id: store.store_id, 
+        //             simulation_instance_id: getSimulationInstanceId(),
+        //             simulation_step: getSimulationStep(),
+        //             }
+        //         })
+        //         .then(response => {
+        //             console.log('Store removed:', store.name);
 
-                    // Make sure to untrack the store removed via popup (don't include as a highlighted marker)
-                    const highlightedStores = window.storeMarkers.filter(marker => marker.isHighlighted);
-                    highlightedStores.forEach(marker => {
-                        const storeID = marker.storeId;
-                        if(storeID === store.store_id) {
-                            // Remove the marker from the map
-                            map.removeLayer(marker);
+        //             // Make sure to untrack the store removed via popup (don't include as a highlighted marker)
+        //             const highlightedStores = window.storeMarkers.filter(marker => marker.isHighlighted);
+        //             highlightedStores.forEach(marker => {
+        //                 const storeID = marker.storeId;
+        //                 if(storeID === store.store_id) {
+        //                     // Remove the marker from the map
+        //                     map.removeLayer(marker);
 
-                            // Remove marker from storeMarkers array
-                            const index = window.storeMarkers.indexOf(marker);
-                            if (index > -1) window.storeMarkers.splice(index, 1);
-                       }
-                    });
+        //                     // Remove marker from storeMarkers array
+        //                     const index = window.storeMarkers.indexOf(marker);
+        //                     if (index > -1) window.storeMarkers.splice(index, 1);
+        //                }
+        //             });
 
-                    // update map
-                    //
-                    window.stores = response.data.store_json;
-                    //rerender();
-                })
-            } 
-            catch(error) {
-                console.error('Error removing store:', error);
-            };
-        });
-        td3.appendChild(button);
+        //             // update map
+        //             //
+        //             window.stores = response.data.store_json;
+        //             //rerender();
+        //         })
+        //     } 
+        //     catch(error) {
+        //         console.error('Error removing store:', error);
+        //     };
+        // });
+        //td3.appendChild(button);
         tr3.appendChild(td3);
         tbody.appendChild(tr3);
 
@@ -276,11 +217,39 @@ export function initializeMap(mapId, households, stores) {
         marker.isHighlighted = false;
         marker.storeId = store.store_id;
 
+        // Unhighlight all markers when clicking on the map (not on a marker)
+        map.on('click', (e) => {
+            window.storeMarkers?.forEach(marker => {
+                if (marker.isHighlighted) {
+                    marker.isHighlighted = false;
+                    if (marker.getElement()) {
+                        marker.getElement().style.border = 'none';
+                    }
+                }
+            });
+        });
+
         // When clicked, toggle highlight state and update marker highlighting on map
-        marker.on('click', () => {
+        marker.on('click', (e) => {
+            const isCtrl = e.originalEvent.ctrlKey || e.originalEvent.metaKey; // Ctrl on Windows/Linux, Cmd on Mac
+            
+            // When no ctrl toggle
+            if (!isCtrl) {
+                // Unhighlight all other markers
+                window.storeMarkers.forEach(m => {
+                    if (m !== marker) {
+                        m.isHighlighted = false;
+                        if (m.getElement()) {
+                            m.getElement().style.border = 'none';
+                        }
+                    }
+                });
+            }
+            
+            // When ctrl toggle 
             marker.isHighlighted = !marker.isHighlighted;
             if(marker.getElement()) {
-                marker.getElement().style.filter = marker.isHighlighted ? 'drop-shadow(0 0 0px red) drop-shadow(0 0 0px red) drop-shadow(0 0 0px red)' : '';
+                marker.getElement().style.border = marker.isHighlighted ? '2px solid white' : 'none';
             }
         });
 
@@ -325,7 +294,7 @@ export function initializeMap(mapId, households, stores) {
         });
     }
 
-    function handleRemoveStores() {
+    function handleRemoveStores(confirmed) {
         if (!window.storeMarkers) {
             console.warn('No store markers found.');
             return false;
@@ -335,12 +304,10 @@ export function initializeMap(mapId, households, stores) {
         const highlighted = window.storeMarkers.filter(m => m.isHighlighted);
         if (highlighted.length === 0) return false;
 
-        // Confirmation popup
-        const confirmed = window.confirm(`Would you like to delete these ${highlighted.length} store(s)?`);
-        if (!confirmed) return false;
-
         // Call the existing delete logic
-        deleteHighlightedStores();
+        if(confirmed) {
+            deleteHighlightedStores();
+        }
         return true;
     }
 

--- a/fass-react/src/components/RemoveMultipleStoreModal.jsx
+++ b/fass-react/src/components/RemoveMultipleStoreModal.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Modal, Button } from "react-bootstrap";
+
+const RemoveMultipleStoreModal = ({ show, onConfirm, onCancel }) => {
+  return (
+    <Modal show={show} onHide={onCancel}>
+      <Modal.Header closeButton>
+        <Modal.Title>Confirm Removal</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        Are you sure you want to remove the highlighted store(s)?
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+        <Button variant="primary" onClick={onConfirm}>
+          Confirm
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default RemoveMultipleStoreModal;

--- a/fass-react/src/components/RemoveStoreButton.jsx
+++ b/fass-react/src/components/RemoveStoreButton.jsx
@@ -1,29 +1,55 @@
 import React, { useState } from 'react';
 import { Button } from 'react-bootstrap';
 import RemoveStoreModal from './RemoveStoreModal';
+import RemoveMultipleStoreModal from "./RemoveMultipleStoreModal";
 
-const RemoveStoreButton = () => {
+const RemoveStoreButton = ({ onConfirm }) => {
     const [showModal, setShowModal] = useState(false);
+    const [showConfirmModal, setShowConfirmModal] = useState(false);
+
     const handleClose = () => setShowModal(false);
+    const handleConfirmClose = () => setShowConfirmModal(false);
 
     const handleClick = () => {
-      // Try to remove highlighted stores directly
-      const handled = window.handleRemoveStores?.();
-      if (!handled) {
-        // No highlighted stores, show modal for manual selection
-        setShowModal(true);
-      }
+        // Try to remove highlighted stores directly
+        const handled = window.handleRemoveStores?.();
+        if (!handled) {
+            // No highlighted stores, show modal for manual selection
+            setShowModal(true);
+        } else {
+            // Highlighted stores exist, show mini confirmation modal
+            setShowConfirmModal(true);
+        }
+    };
+
+    const handleConfirm = () => {
+        window.handleRemoveStores?.(true); 
+        if (onConfirm) {
+          onConfirm(true);
+        }
+        setShowConfirmModal(false);
+    };
+
+    const handleCancel = () => {
+        if (onConfirm) {
+          onConfirm(false);
+        }
+        setShowConfirmModal(false);
     };
 
     return (
-      <>
-       <Button variant="primary" onClick={handleClick}>
-        Remove Store
-       </Button>
-       <RemoveStoreModal show={showModal} handleClose={handleClose} />
-      </>
+        <>
+            <Button variant="primary" onClick={handleClick}>
+                Remove Store
+            </Button>
+
+            {/* Modal for "no stores selected" */}
+            <RemoveStoreModal show={showModal} handleClose={handleClose} />
+
+            {/* Mini confirmation modal for multiple highlighted stores */}
+            <RemoveMultipleStoreModal show={showConfirmModal} onConfirm={handleConfirm} onCancel={handleCancel}/>
+        </>
     );
 };
 
 export default RemoveStoreButton;
-  


### PR DESCRIPTION
The following are addressed in this commit:

1. The new store types are now selectable.
2. The popups no longer display the "Remove Store" button.
3. After clicking cancel on the confirm dialog, the previous select by list dialog is no longer displayed.
4. The confirm dialog that comes up is now an application dialog, consistent with the other modals.  
5. Stores now deselect when clicking on the map. 
  a) When a new item is selected, any previously selected items are deselected.
  b) To select multiple items, usually a shift or control key is held down while clicking to select.
  c) When the background element is selected, all currently selected items are deselected.
6. A white square border is put around selected store markers to make it easier to see (the color can be changed if needed).