### PR TITLE
Fixed bug in the interaction between store removal and stepping in the simulation.

### DIFF
--- a/fass-react/src/App.jsx
+++ b/fass-react/src/App.jsx
@@ -415,6 +415,7 @@ const App = () => {
     let simulationInstanceId = getSimulationInstanceId();
     if (simulationInstanceId) {
       loadHouseholds(simulationInstanceId);
+      loadStores(simulationInstanceId);
     }
   }, [stepNumber]);
 

--- a/fass-react/src/components/StepButton.jsx
+++ b/fass-react/src/components/StepButton.jsx
@@ -20,6 +20,12 @@ const StepButton = ({updateStepNumber}) => {
                 throw new Error('Network response was not ok');
             }
             console.log(response.data);
+
+            // reset highlight state
+            window.storeMarkers?.forEach(marker => {
+              marker.isHighlighted = false;
+            });
+
             updateStepNumber(getSimulationStep() + 1);
             setLoading(false)
         })


### PR DESCRIPTION
The markers are properly shown with or without store removals after the simulation is stepped through. Note that the update takes a second, and the old marker may still appear for a second, but it will disappear automatically after a moment without further user action. I tried many other methods to solve this issue, but I could not find a cleaner solution. As a result, I reverted to this quicker solution.