### PR TITLE
Inline custom-theme body styles to avoid FOUC

### DIFF
--- a/fass-react/index.html
+++ b/fass-react/index.html
@@ -7,6 +7,10 @@
     <title>Food Equity Access Simulation Technology (FEAST)</title>
     <link rel="stylesheet" href="markercluster/MarkerCluster.css" />
     <link rel="stylesheet" href="markercluster/MarkerCluster.Default.css" />
+    <style>
+      /* Critical theme styles inlined to avoid FOUC before index.css loads */
+      body.custom-theme { background-color: #000928; color: #FFFFFF; }
+    </style>
   </head>
   <body class="custom-theme">
     <div id="loading" class="overlay" style="visibility:hidden">


### PR DESCRIPTION
## Summary
- Inline the `.custom-theme` body background/color rule into `index.html` so the dark navy theme paints from the first frame
- Eliminates the white flash on hard loads of `/simulation` (the rule previously lived only in `src/index.css`, which Vite injects via JS after the HTML parses)

## Test plan
- [ ] Hard reload `/simulation` (e.g. Ctrl+Shift+R) and confirm no white-to-navy flash
- [ ] Navigate to `/` (Landing) and back to `/simulation` and confirm appearance is unchanged from before
- [ ] Production build (`npm run build && npm run preview`) renders the same dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)