### PR TITLE
Inline custom-theme body styles to avoid FOUC

### DIFF
--- a/fass-react/index.html
+++ b/fass-react/index.html
@@ -7,6 +7,10 @@
     <title>Food Equity Access Simulation Technology (FEAST)</title>
     <link rel="stylesheet" href="markercluster/MarkerCluster.css" />
     <link rel="stylesheet" href="markercluster/MarkerCluster.Default.css" />
+    <style>
+      /* Critical theme styles inlined to avoid FOUC before index.css loads */
+      body.custom-theme { background-color: #000928; color: #FFFFFF; }
+    </style>
   </head>
   <body class="custom-theme">
     <div id="loading" class="overlay" style="visibility:hidden">


### PR DESCRIPTION
## Summary
- Promote PR #47 from staging to main
- Inlines the `.custom-theme` body background/color into `index.html` so the dark navy theme paints from the first frame, eliminating the white-to-navy flash on hard loads

## Test plan
- [ ] Hard reload `/simulation` and confirm no FOUC
- [ ] Navigate `/` ↔ `/simulation` and confirm appearance is unchanged
- [ ] Production build still renders the dark theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)