### PR TITLE
Replace hardcoded custom-theme colors with CSS variables

### DIFF
--- a/fass-react/index.html
+++ b/fass-react/index.html
@@ -9,7 +9,8 @@
     <link rel="stylesheet" href="markercluster/MarkerCluster.Default.css" />
     <style>
       /* Critical theme styles inlined to avoid FOUC before index.css loads */
-      body.custom-theme { background-color: #000928; color: #FFFFFF; }
+      :root { --icicle-page: #F4F6FB; --icicle-primary: #0B1F4E; }
+      body.custom-theme { background-color: var(--icicle-page); color: var(--icicle-primary); }
     </style>
   </head>
   <body class="custom-theme">

--- a/fass-react/src/index.css
+++ b/fass-react/src/index.css
@@ -24,26 +24,10 @@ h1, h2, h3 {
 	color: var(--icicle-primary);
 }
 
-/* Custom theme: dark navy background with white buttons and a #142551 accent */
+/* Custom theme: uses ICICLE CSS variables for colors */
 .custom-theme {
-	background-color: #000928;
-	color: #FFFFFF;
-}
-.custom-theme .btn,
-.custom-theme button {
-	background-color: #FFFFFF;
-	border-color: #142551;
-	color: #000928;
-}
-.custom-theme .btn:hover,
-.custom-theme .btn:focus,
-.custom-theme .btn:active,
-.custom-theme button:hover,
-.custom-theme button:focus,
-.custom-theme button:active {
-	background-color: #142551;
-	border-color: #142551;
-	color: #FFFFFF;
+	background-color: var(--icicle-page);
+	color: var(--icicle-primary);
 }
 
 /* Brand primary buttons to the ICICLE navy */


### PR DESCRIPTION
## Summary
- Inline `:root` variable definitions in `index.html` so they're available before `index.css` loads (preserving FOUC prevention)
- Replace hardcoded `#000928`/`#FFFFFF` in `.custom-theme` with `var(--icicle-page)`/`var(--icicle-primary)`
- Remove white-button overrides from `.custom-theme` so standard `.btn-primary` navy styles apply

## Problem
The hardcoded dark values in `custom-theme` forced a dark navy background with white text across the whole app, making the legend labels, data panel text, and buttons invisible or incorrectly styled on the simulation page.

## Test plan
- [ ] Simulation page background is light (`#F4F6FB`)
- [ ] Data panel text is visible (dark on light background)
- [ ] Legend labels are visible
- [ ] Buttons are dark navy (not white outline)
- [ ] No flash of dark background on page load (FOUC check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)